### PR TITLE
Typo in wakeup_enable.py script

### DIFF
--- a/Software/README.md
+++ b/Software/README.md
@@ -125,11 +125,11 @@ This feature will only work if you are either plugged in to the PiJuice microUSB
 
 When setting the Wakeup alarm for a repeated wakeup, after the initial reboot the Wakeup enabled capability is disabled due to the Raspbian RTC clock initialisation resetting the bit in the PiJuice firmware. To overcome this you will need to run a script to re-enable the wakeup-enable capability. The script is located in PiJuice > Software > Test > wakeup_enable.py
 
-```bash
+```python
 # This script is started at reboot by cron
 # Since the start is very early in the boot sequence we wait for the i2c-1 device
 
-import pijuice, time
+import os, pijuice, time
 
 while not os.path.exists('/dev/i2c-1'):
     time.sleep(0.1)


### PR DESCRIPTION
There is missing `import os` in wakeup snippet within README file.